### PR TITLE
Up font-space-mono to use main instead of master

### DIFF
--- a/Casks/font-space-mono.rb
+++ b/Casks/font-space-mono.rb
@@ -2,12 +2,12 @@ cask "font-space-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/googlefonts/spacemono/archive/master.zip"
+  url "https://github.com/googlefonts/spacemono/archive/main.zip"
   name "Space Mono"
   homepage "https://github.com/googlefonts/spacemono"
 
-  font "spacemono-master/fonts/SpaceMono-Bold.ttf"
-  font "spacemono-master/fonts/SpaceMono-BoldItalic.ttf"
-  font "spacemono-master/fonts/SpaceMono-Italic.ttf"
-  font "spacemono-master/fonts/SpaceMono-Regular.ttf"
+  font "spacemono-main/fonts/SpaceMono-Bold.ttf"
+  font "spacemono-main/fonts/SpaceMono-BoldItalic.ttf"
+  font "spacemono-main/fonts/SpaceMono-Italic.ttf"
+  font "spacemono-main/fonts/SpaceMono-Regular.ttf"
 end


### PR DESCRIPTION
Correctly patch file to use main instead of master.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
